### PR TITLE
Free ldapai_extensions correctly

### DIFF
--- a/src/QoreLdapClient.h
+++ b/src/QoreLdapClient.h
@@ -356,8 +356,7 @@ public:
             ldap_memfree(apiInfo.ldapai_vendor_name);
             apiInfo.ldapai_vendor_name = 0;
             if (apiInfo.ldapai_extensions) {
-                size_t nextensions = sizeof(apiInfo.ldapai_extensions) / sizeof(apiInfo.ldapai_extensions[0]);
-                for (size_t i = 0; i < nextensions; ++i) {
+                for (size_t i = 0; apiInfo.ldapai_extensions[i]; ++i) {
                     ldap_memfree(apiInfo.ldapai_extensions[i]);
                 }
                 ldap_memfree(apiInfo.ldapai_extensions);


### PR DESCRIPTION
nextensions will always be 1 and this might cause
memory leaks. Walk throu the array freeing all
items in it instead. The code assumes that the
array ends with NULL. This assumption is made
in other parts of the code, so the commiter
assumes it to be correct.
Should fix qorelanguage/qore#4416 .